### PR TITLE
Add variables and outputs

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -113,9 +113,9 @@ module "eks" {
   eks_managed_node_groups = {
 
     default = {
-      min_size     = var.node_min_count
-      max_size     = var.node_max_count
-      desired_size = var.node_desired_count
+      min_size     = var.node_min_size
+      max_size     = var.node_max_size
+      desired_size = var.node_desired_size
 
       iam_role_name              = "${var.name}-node-role"
       iam_role_use_name_prefix   = false

--- a/main.tf
+++ b/main.tf
@@ -98,18 +98,6 @@ module "eks" {
 
   manage_aws_auth_configmap = true
 
-  eks_managed_node_group_defaults = {
-    ami_type       = "AL2_x86_64"
-    instance_types = ["t3.medium"]
-
-    # We are using the IRSA created below for permissions
-    # However, we have to deploy with the policy attached FIRST (when creating a fresh cluster)
-    # and then turn this off after the cluster/node group is created. Without this initial policy,
-    # the VPC CNI fails to assign IPs and nodes cannot join the cluster
-    # See https://github.com/aws/containers-roadmap/issues/1666 for more context
-    iam_role_attach_cni_policy = true
-  }
-
   eks_managed_node_groups = {
 
     default = {
@@ -121,8 +109,10 @@ module "eks" {
       iam_role_use_name_prefix   = false
       use_custom_launch_template = false
 
-      ami_type = var.node_ami_type
-      platform = var.node_platform
+      ami_type                   = var.node_ami_type
+      platform                   = var.node_platform
+      instance_types             = var.node_instance_types
+      iam_role_attach_cni_policy = true
     }
   }
 

--- a/main.tf
+++ b/main.tf
@@ -133,8 +133,8 @@ module "vpc" {
   azs = local.azs
   # cidrsubnet function docs can be found here: https://developer.hashicorp.com/terraform/language/functions/cidrsubnet
   private_subnets = [for k, v in local.azs : cidrsubnet(var.vpc_cidr, 4, k)]
-  public_subnets  = [for k, v in local.azs : cidrsubnet(var.vpc_cidr, 8, k + 48)]
-  intra_subnets   = [for k, v in local.azs : cidrsubnet(var.vpc_cidr, 8, k + 52)]
+  public_subnets  = [for k, v in local.azs : cidrsubnet(var.vpc_cidr, 8, k + 96)]
+  intra_subnets   = [for k, v in local.azs : cidrsubnet(var.vpc_cidr, 8, k + 102)]
 
   enable_nat_gateway     = true
   single_nat_gateway     = true

--- a/outputs.tf
+++ b/outputs.tf
@@ -8,11 +8,6 @@ output "load_balancer_hostname" {
   value       = data.kubernetes_service.nginx_ingress.status[0].load_balancer[0].ingress[0].hostname
 }
 
-output "service_nginx_ingress" {
-  description = "Hostname of load balancer created by nginx-ingress-controller"
-  value       = data.kubernetes_service.nginx_ingress
-}
-
 output "vpc" {
   description = "Details of resources created by vpc module"
   value       = module.vpc

--- a/outputs.tf
+++ b/outputs.tf
@@ -1,0 +1,56 @@
+output "elastic_ip_address" {
+  description = "Elastic IP Address managed by GeoWeb module"
+  value       = module.vpc.nat_public_ips[0]
+}
+
+output "load_balancer_hostname" {
+  description = "Hostname of load balancer created by nginx-ingress-controller"
+  value       = data.kubernetes_service.nginx_ingress.status[0].load_balancer[0].ingress[0].hostname
+}
+
+output "service_nginx_ingress" {
+  description = "Hostname of load balancer created by nginx-ingress-controller"
+  value       = data.kubernetes_service.nginx_ingress
+}
+
+output "vpc" {
+  description = "Details of resources created by vpc module"
+  value       = module.vpc
+  sensitive   = true
+}
+
+output "eks" {
+  description = "Details of resources created by eks module"
+  value       = module.eks
+  sensitive   = true
+}
+
+output "dynamodb_lock" {
+  description = "Details of dynamodb table resource"
+  value       = resource.aws_dynamodb_table.dynamodb-terraform-state-lock
+  sensitive   = true
+}
+
+output "helm_metrics_server" {
+  description = "Details of metrics-server helm release"
+  value       = resource.helm_release.metrics-server
+  sensitive   = true
+}
+
+output "helm_nginx_ingress_controller" {
+  description = "Details of nging-ingress-controller helm release"
+  value       = resource.helm_release.nginx-ingress-controller
+  sensitive   = true
+}
+
+output "helm_secrets_store_csi_driver" {
+  description = "Details of secrets-store-csi-driver helm release"
+  value       = resource.helm_release.secrets-store-csi-driver
+  sensitive   = true
+}
+
+output "helm_secrets_store_csi_driver_provider" {
+  description = "Details of secrets-store-csi-driver-provider helm release"
+  value       = resource.helm_release.secrets-store-csi-driver-provider
+  sensitive   = true
+}

--- a/outputs.tf
+++ b/outputs.tf
@@ -1,11 +1,13 @@
 output "elastic_ip_address" {
   description = "Elastic IP Address managed by GeoWeb module"
   value       = module.vpc.nat_public_ips[0]
+  sensitive   = true
 }
 
 output "load_balancer_hostname" {
   description = "Hostname of load balancer created by nginx-ingress-controller"
   value       = data.kubernetes_service.nginx_ingress.status[0].load_balancer[0].ingress[0].hostname
+  sensitive   = true
 }
 
 output "vpc" {

--- a/variables.tf
+++ b/variables.tf
@@ -27,17 +27,17 @@ variable "vpc_cidr" {
   default = "10.0.0.0/16"
 }
 
-variable "node_min_count" {
+variable "node_min_size" {
   type    = string
   default = "1"
 }
 
-variable "node_max_count" {
+variable "node_max_size" {
   type    = string
   default = "5"
 }
 
-variable "node_desired_count" {
+variable "node_desired_size" {
   type    = string
   default = "1"
 }

--- a/variables.tf
+++ b/variables.tf
@@ -52,6 +52,11 @@ variable "node_platform" {
   default = "bottlerocket"
 }
 
+variable "node_instance_types" {
+  type    = list(string)
+  default = ["t3.medium"]
+}
+
 variable "helm_chart_used_namespace" {
   type    = string
   default = "kube-system"

--- a/variables.tf
+++ b/variables.tf
@@ -2,10 +2,6 @@ variable "certificateARN" {
   type = string
 }
 
-variable "accountId" {
-  type = string
-}
-
 variable "name" {
   type    = string
   default = "geoweb"
@@ -19,4 +15,64 @@ variable "region" {
 variable "lock_name" {
   type    = string
   default = "default-dynamodb-terraform-state-lock"
+}
+
+variable "cluster_version" {
+  type    = string
+  default = "1.28"
+}
+
+variable "vpc_cidr" {
+  type    = string
+  default = "10.0.0.0/16"
+}
+
+variable "node_min_count" {
+  type    = string
+  default = "1"
+}
+
+variable "node_max_count" {
+  type    = string
+  default = "5"
+}
+
+variable "node_desired_count" {
+  type    = string
+  default = "1"
+}
+
+variable "node_ami_type" {
+  type    = string
+  default = "BOTTLEROCKET_x86_64"
+}
+
+variable "node_platform" {
+  type    = string
+  default = "bottlerocket"
+}
+
+variable "helm_chart_used_namespace" {
+  type    = string
+  default = "kube-system"
+}
+
+variable "nging_ingress_controller_version" {
+  type    = string
+  default = "4.7.2"
+}
+
+variable "secrets_store_csi_driver_version" {
+  type    = string
+  default = "1.3.4"
+}
+
+variable "secrets_store_csi_driver_provider_version" {
+  type    = string
+  default = "0.3.4"
+}
+
+variable "metrics_server_version" {
+  type    = string
+  default = "3.11.0"
 }


### PR DESCRIPTION
* Added variables
* Added outputs
* Modified subnet cidr range calculations, it now supports 3-6 availability zones and defaults to using all availability zones from the deployed region (most regions have 3, which was the value used before)

How to test:
* Code review, should there be more variables added? 
* Install terraform+terragrunt & test running the changes with instructions from geoweb-configuration README

Closes https://gitlab.com/opengeoweb/fmi/fmi-aws-config/-/issues/186