### PR TITLE
Add more configurability to OIDC

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -361,8 +361,8 @@ resource "aws_iam_role" "terraform-clusterAdmin-iam-role" {
         "Action" : "sts:AssumeRoleWithWebIdentity",
         "Condition" : {
           "StringLike" : {
-            "${var.oidcProvider}:aud" : "sts.amazonaws.com"
-            "${var.oidcProvider}:sub" : "${var.oidcAllowedRepositoryAndBranch}"
+            "${var.oidcProvider}:aud" : var.oidcAudience,
+            "${var.oidcProvider}:sub" : var.oidcAllowedRepositoryAndBranch
           }
         }
       },
@@ -374,10 +374,8 @@ resource "aws_iam_role" "terraform-clusterAdmin-iam-role" {
         "Action" : "sts:AssumeRoleWithWebIdentity",
         "Condition" : {
           "StringLike" : {
-            "${module.eks.oidc_provider}:aud" : "sts.amazonaws.com",
-            "${module.eks.oidc_provider}:sub" : [
-              "system:serviceaccount:*:*"
-            ]
+            "${module.eks.oidc_provider}:aud" : var.oidcAudience,
+            "${module.eks.oidc_provider}:sub" : var.oidcServiceAccounts
           }
         }
       }

--- a/variables.tf
+++ b/variables.tf
@@ -106,3 +106,13 @@ variable "oidcAllowedRepositoryAndBranch" {
   type    = string
   default = "repo:*/*:ref:refs/heads/*"
 }
+
+variable "oidcServiceAccounts" {
+  type    = list(string)
+  default = ["system:serviceaccount:*:*"]
+}
+
+variable "oidcAudience" {
+  type    = string
+  default = "sts.amazonaws.com"
+}


### PR DESCRIPTION
Made audience and used service accounts configurable with variables

sts.amazonaws.com is the correct when using the offical aws-configure-credentials action, but you could want to configure region specific audience too.