### PR TITLE
Add cloudwatch logging

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -94,6 +94,9 @@ module "eks" {
       service_account_role_arn = module.ebs_csi_irsa_role.iam_role_arn
       most_recent              = true
     }
+    amazon-cloudwatch-observability = {
+      most_recent = true
+    }
   }
 
   vpc_id                   = module.vpc.vpc_id
@@ -124,6 +127,10 @@ module "eks" {
       platform                   = var.node_platform
       instance_types             = var.node_instance_types
       iam_role_attach_cni_policy = true
+
+      iam_role_additional_policies = {
+        CloudWatchAgentServerPolicy = "arn:aws:iam::aws:policy/CloudWatchAgentServerPolicy"
+      }
     }
   }
 


### PR DESCRIPTION
Adds EKS Addon to the created EKS Cluster, along with required extra policy on the node group role.
* Adds 3 cloudwatch log groups:
  * /aws/containerinsights/<cluster_name>/application (the important one containing application container logs)
  * /aws/containerinsights/<cluster_name>/dataplane
  * /aws/containerinsights/<cluster_name>/performance
  
How to test: 
* test-cluster deployed in FMI AWS, you can inspect the logging contents in CloudWatch, I've deployed an example frontend to the cluster and it's logs can be found from the application log group created.